### PR TITLE
:bug: Update de.json

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -486,7 +486,7 @@
     "status.visibility.5": "Vertraute Nutzer",
     "status.visibility.5.detail": "Nur für von dir vertrauten Nutzern sichtbar",
     "status.update.success": "Dein Status wurde erfolgreich aktualisiert.",
-    "status.manual_journey_number": "Fahrtennummer manuell eingeben",
+    "status.manual_journey_number": "Fahrtennummer manuell eingegeben",
     "status.show_more": "Mehr anzeigen",
     "time-format": "HH:mm",
     "time-format.with-day": "HH:mm (DD.MM.YYYY)",


### PR DESCRIPTION
Hovern über einer Zugnummer lässt "Fahrtennummer manuell eingeben" erscheinen, im Englischen steht "journey number manually overwritten", also muss es "eingegeben" werden

<img width="579" height="514" alt="temp" src="https://github.com/user-attachments/assets/32a6a32e-2686-4740-91c8-10ab1467664b" />
